### PR TITLE
Add xing as contact

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Currently, Awesome Identity supports: Email, GitHub, Twitter, Facebook, LinkedIn
   stackoverflow = "7919458"
   keybase = "john.smith"
   medium = "john.smith"
+  xing = "john.smith"
 ```
 
 ### Footer

--- a/layouts/partials/contacts.html
+++ b/layouts/partials/contacts.html
@@ -17,6 +17,10 @@
   <a class="contact" href="https://linkedin.com/in/{{ $id }}">
     <i class="fab fa-linkedin" aria-hidden="true"></i>
   </a>
+    {{- else if (eq $service "xing") }}
+  <a class="contact" href="https://xing.com/profile/{{ $id }}">
+    <i class="fab fa-xing" aria-hidden="true"></i>
+  </a>
     {{- else if (eq $service "instagram") }}
   <a class="contact" href="https://instagram.com/{{ $id }}">
     <i class="fab fa-instagram" aria-hidden="true"></i>


### PR DESCRIPTION
Just stumbled upon your template, looks awesome! What's missing for me is xing, the german counterpart to LinkedIn. I added it as a possible contact.