### PR TITLE
Add matrix contact

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -17,6 +17,7 @@
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/normalize.css@8.0.1/normalize.css">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fork-awesome@1.1.7/css/fork-awesome.min.css" integrity="sha256-gsmEoJAws/Kd3CjuOQzLie5Q3yshhvmo7YNtBG7aaEY=" crossorigin="anonymous">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,700">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Jura:400,700">
 

--- a/layouts/partials/contacts.html
+++ b/layouts/partials/contacts.html
@@ -53,6 +53,10 @@
   <a class="contact" href="https://hackerrank.com/{{ $id }}">
     <i class="fab fa-hackerrank" aria-hidden="true"></i>
   </a>
+    {{- else if (eq $service "matrix") }}
+  <a class="contact" href="https://matrix.to/#/{{ $id }}">
+    <i class="fa fa-matrix-org" aria-hidden="true"></i>
+  </a>
     {{- end }}
   {{- end }}
 </section>


### PR DESCRIPTION
Add matrix contact template.

Be aware that `fontawesome` does not contain a `matrix-org` icon, yet (see https://github.com/FortAwesome/Font-Awesome/issues/12808). To circumvent this, the `ForkAwesome` icon package is now loaded in addition (https://forkawesome.github.io/Fork-Awesome/icon/matrix-org/).