### PR TITLE
Update crisp.html

### DIFF
--- a/layouts/partials/crisp.html
+++ b/layouts/partials/crisp.html
@@ -1,4 +1,4 @@
-{{- $ga := .Site.GoogleAnalytics -}}
+{{- $ga := .Site.Config.Services.GoogleAnalytics.ID -}}
 {{ with .Site.Params.crisp -}}
 {{ if .websiteid -}}
 <script type="text/javascript">


### PR DESCRIPTION
`.Site.GoogleAnalytics` was deprecated in Hugo v0.120.0. Using `.Site.Config.Services.GoogleAnalytics.ID` instead.