### PR TITLE
Update GA (and Hugo min. version) after deprecations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,26 +32,10 @@ commands:
 
 
 jobs:
-  build-hugo-0-55:
+  build-hugo-0-134:
     executor:
       name: hugo
-      version: "0.55"
-    steps:
-    - checkout_with_git_submodules
-    - build_hugo
-    - test_html
-  build-hugo-0-54:
-    executor:
-      name: hugo
-      version: "0.54"
-    steps:
-    - checkout_with_git_submodules
-    - build_hugo
-    - test_html
-  build-hugo-0-53:
-    executor:
-      name: hugo
-      version: "0.53"
+      version: "0.134"
     steps:
     - checkout_with_git_submodules
     - build_hugo
@@ -62,7 +46,5 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-    - build-hugo-0-55
-    - build-hugo-0-54
-    - build-hugo-0-53
+    - build-hugo-0-134
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -37,7 +37,7 @@
 {{ partial "actions.html" . }}
     </div>
 {{ partial "footer.html" . }}
-{{ template "_internal/google_analytics_async.html" . }}
+{{ template "_internal/google_analytics.html" . }}
 {{ partial "crisp.html" . }}
   </body>
 </html>

--- a/layouts/partials/crisp.html
+++ b/layouts/partials/crisp.html
@@ -1,4 +1,4 @@
-{{- $ga := .Site.GoogleAnalytics -}}
+{{- $ga := .Site.Config.Services.GoogleAnalytics.ID -}}
 {{ with .Site.Params.crisp -}}
 {{ if .websiteid -}}
 <script type="text/javascript">

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   command = "hugo --gc --minify --source exampleSite --themesDir ../../ -t repo --baseURL $HUGO_BASE_URL"
 
 [context.production.environment]
-  HUGO_VERSION = "0.74.3"
+  HUGO_VERSION = "0.134"
   HUGO_ENV = "production"
   HUGO_ENABLEGITINFO = "true"
   HUGO_BASE_URL = "https://awesome-identity.netlify.com"
@@ -12,13 +12,13 @@
 command = "hugo --gc --minify --buildFuture --source exampleSite --themesDir ../../ -t repo --baseURL $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.74.3"
+  HUGO_VERSION = "0.134"
 
 [context.branch-deploy]
 command = "hugo --gc --minify --source exampleSite --themesDir ../../ -t repo --baseURL $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
-HUGO_VERSION = "0.74.3"
+HUGO_VERSION = "0.134"
 
 [[redirects]]
   from = "/*"

--- a/theme.toml
+++ b/theme.toml
@@ -8,7 +8,7 @@ tags = [
   "responsive", "mobile", "one-page", "onepage", "light", "landing page", "starter"
 ]
 features = ["analytics", "favicon", "livechat"]
-min_version = "0.53"
+min_version = "0.126"
 
 [author]
   name = "Byungjin Park"


### PR DESCRIPTION
Fix #28.

Notes:

- `tpl/tplimpl/embedded/templates/google_analytics_async.html` has been [deprecated](gohugoio/hugo@c32094ace113412abea354b7119d154168097287) since Hugo [v0.119.0](https://github.com/gohugoio/hugo/releases/tag/v0.119.0), and was [removed](gohugoio/hugo@ebfca61ac4d4b62b3e4a50477826a85c06b44552) in Hugo [v0.125.0](https://github.com/gohugoio/hugo/releases/tag/v0.125.0), `tpl/tplimpl/embedded/templates/google_analytics.html` becoming the only GA template.
- `site.GoogleAnalytics` has been [deprecated](gohugoio/hugo@a692278bc679af44f69cc49c11efc412edd979a0) since Hugo [v0.120.0](https://github.com/gohugoio/hugo/releases/tag/v0.120.0), and its use with the latest Hugo versions currently triggers an error, as per Hugo [deprecation](https://gohugo.io/troubleshooting/deprecation/) process.
