### PR TITLE
:arrow_up: Modernize templates for current Hugo (0.163.x)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ Session.vim
 tags
 # Persistent undo
 [._]*.un~
+.hugo_build.lock
+exampleSite/public/
+exampleSite/resources/_gen/

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Jura:400,700">
 
 {{ $options := (dict "targetPath" "css/style.css" "outputStyle" "compressed") }}
-{{ $style := resources.Get "sass/main.scss" | toCSS $options | fingerprint }}
+{{ $style := resources.Get "sass/main.scss" | css.Sass $options | fingerprint }}
     <link rel="stylesheet" href="{{ $style.RelPermalink }}">
     <!-- <link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}"> -->
 
@@ -37,7 +37,7 @@
 {{ partial "actions.html" . }}
     </div>
 {{ partial "footer.html" . }}
-{{ template "_internal/google_analytics_async.html" . }}
+{{ template "_internal/google_analytics.html" . }}
 {{ partial "crisp.html" . }}
   </body>
 </html>

--- a/layouts/partials/crisp.html
+++ b/layouts/partials/crisp.html
@@ -1,4 +1,4 @@
-{{- $ga := .Site.GoogleAnalytics -}}
+{{- $ga := site.Config.Services.GoogleAnalytics.ID -}}
 {{ with .Site.Params.crisp -}}
 {{ if .websiteid -}}
 <script type="text/javascript">
@@ -22,19 +22,19 @@
   {{- end }}
   {{ if $ga -}}
   $crisp.push(["on", "chat:initiated", function() {
-    ga('send', 'event', 'Chat', 'Chat Initiated');
+    gtag('event', 'Chat Initiated', { 'event_category': 'Chat' });
   }]);
   $crisp.push(["on", "chat:opened", function() {
-    ga('send', 'event', 'Chat', 'Chat Opened');
+    gtag('event', 'Chat Opened', { 'event_category': 'Chat' });
   }]);
   $crisp.push(["on", "chat:closed", function() {
-    ga('send', 'event', 'Chat', 'Chat Closed');
+    gtag('event', 'Chat Closed', { 'event_category': 'Chat' });
   }]);
   $crisp.push(["on", "message:sent", function() {
-    ga('send', 'event', 'Chat', 'Message Sent');
+    gtag('event', 'Message Sent', { 'event_category': 'Chat' });
   }]);
   $crisp.push(["on", "message:received", function() {
-    ga('send', 'event', 'Chat', 'Message Received');
+    gtag('event', 'Message Received', { 'event_category': 'Chat' });
   }]);
   {{- end }}
 </script>

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,22 +3,22 @@
   command = "hugo --gc --minify --source exampleSite --themesDir ../../ -t repo --baseURL $HUGO_BASE_URL"
 
 [context.production.environment]
-  HUGO_VERSION = "0.74.3"
+  HUGO_VERSION = "0.163.1"
   HUGO_ENV = "production"
   HUGO_ENABLEGITINFO = "true"
-  HUGO_BASE_URL = "https://awesome-identity.netlify.com"
+  HUGO_BASE_URL = "https://awesome-identity.netlify.app"
 
 [context.deploy-preview]
 command = "hugo --gc --minify --buildFuture --source exampleSite --themesDir ../../ -t repo --baseURL $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.74.3"
+  HUGO_VERSION = "0.163.1"
 
 [context.branch-deploy]
 command = "hugo --gc --minify --source exampleSite --themesDir ../../ -t repo --baseURL $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
-HUGO_VERSION = "0.74.3"
+HUGO_VERSION = "0.163.1"
 
 [[redirects]]
   from = "/*"

--- a/theme.toml
+++ b/theme.toml
@@ -8,7 +8,7 @@ tags = [
   "responsive", "mobile", "one-page", "onepage", "light", "landing page", "starter"
 ]
 features = ["analytics", "favicon", "livechat"]
-min_version = "0.53"
+min_version = "0.128.0"
 
 [author]
   name = "Byungjin Park"


### PR DESCRIPTION
## Summary

The theme no longer builds on current Hugo (`error building site: no such template "_internal/google_analytics_async.html"`). This PR updates the templates and toolchain pins so it builds on Hugo 0.163.1 while keeping behavior unchanged.

- Replace the removed `_internal/google_analytics_async.html` with the current `_internal/google_analytics.html` (GA4 / gtag.js — set `googleAnalytics = "G-XXXX"` in site config)
- Replace deprecated `toCSS` with `css.Sass` (renamed in Hugo 0.128)
- Replace removed `.Site.GoogleAnalytics` with `site.Config.Services.GoogleAnalytics.ID` in the Crisp partial, and migrate its chat-event tracking from the old `ga()` (analytics.js) calls to `gtag()` so events keep firing under GA4
- `theme.toml`: `min_version` 0.53 → 0.128.0 (the `css.Sass` floor)
- `netlify.toml`: `HUGO_VERSION` 0.74.3 → 0.163.1; fix the retired `netlify.com` domain → `netlify.app`
- `.gitignore`: ignore `.hugo_build.lock` and `exampleSite` build artifacts

## Behavior note (the one functional caveat)

Google Analytics output moves from the long-dead Universal Analytics (analytics.js) snippet to GA4 gtag.js — required, since UA stopped processing data in 2023 and modern Hugo only ships the GA4 template. A `UA-*` ID will no longer render a tracking snippet; a `G-*` ID is needed.

## Test plan

- [x] `hugo --buildDrafts` on the example site with Hugo 0.163.1 extended: passes (master fails)
- [x] Built with `googleAnalytics` + `params.crisp.websiteid` set: gtag snippet and Crisp loader both render, Crisp event hooks use `gtag()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)