### PR TITLE
:arrow_up: Update CDN assets (Font Awesome 6.7.2, Google Fonts css2)

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -15,10 +15,11 @@
     <base href="{{ .Site.BaseURL }}">
     <title>{{ .Site.Title }}</title>
 
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/normalize.css@8.0.1/normalize.css">
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,700">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Jura:400,700">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/normalize.css@8.0.1/normalize.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Jura:wght@400;700&family=Roboto:wght@100;700&display=swap">
 
 {{ $options := (dict "targetPath" "css/style.css" "outputStyle" "compressed") }}
 {{ $style := resources.Get "sass/main.scss" | toCSS $options | fingerprint }}


### PR DESCRIPTION
## Summary

- **Font Awesome 5.7.2 → 6.7.2** (the final 6.x release). v5 class names used by the theme (`fab fa-github`, `fas fa-envelope`, …) remain fully supported in 6.x, so no template changes are needed. Deliberately *not* 7.x, which changes rendering defaults. Served from cdnjs with the SRI hash taken from the official cdnjs manifest (verified source: https://api.cdnjs.com/libraries/font-awesome/6.7.2)
- **Google Fonts**: combine the two CSS API v1 requests into one css2 request and add `preconnect` hints. `display=swap` is included per current Google Fonts defaults — same final rendering, text just stays visible while fonts load
- **normalize.css**: 8.0.1 is still the latest upstream release; only switched to the minified build

## Test plan

- [x] Example site builds; both new URLs present in the output HTML
- [x] SRI hash for `css/all.min.css` cross-checked against the cdnjs API manifest for 6.7.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)