### PR TITLE
:recycle: Refine templates and styles (no behavior change)

### DIFF
--- a/assets/sass/actions.scss
+++ b/assets/sass/actions.scss
@@ -17,17 +17,13 @@
     &:after {
       content: "";
       transition: 0.5s all ease;
-      -webkit-backface-visibility: hidden;
       backface-visibility: hidden;
       position: absolute;
-    }
-    &:after {
       width: 100%;
       height: 2px;
       left: 50%;
       bottom: -0.3em;
-      background: lighten(rgb(182, 38, 44), 10%);
-      -webkit-transform: translateX(-50%);
+      background: lighten($color-accent, 10%);
       transform: translateX(-50%);
     }
     &:hover:after {

--- a/assets/sass/contacts.scss
+++ b/assets/sass/contacts.scss
@@ -14,14 +14,12 @@
     border-radius: 100%;
     color: #535358;
     text-align: center;
-    -webkit-transition: all 0.3s ease-in-out;
-    -moz-transition: all 0.3s ease-in-out;
     transition: all 0.3s ease-in-out;
   }
   .contact:hover {
-    background: rgb(182, 38, 44);
+    background: $color-accent;
     color: #fff;
-    box-shadow: 0 0 1px 7px rgba(182, 38, 44, 0.15);
+    box-shadow: 0 0 1px 7px rgba($color-accent, 0.15);
     position: relative;
   }
 }

--- a/assets/sass/global.scss
+++ b/assets/sass/global.scss
@@ -27,9 +27,8 @@ body {
 }
 
 a {
-  color: rgb(182, 38, 44);
+  color: $color-accent;
   text-decoration: none;
-  -webkit-transition: color 0.5s;
   transition: color 0.5s;
 
   &:visited,
@@ -40,11 +39,6 @@ a {
 }
 
 ::selection {
-  background-color: rgb(182, 38, 44);
-  color: white;
-}
-
-::-moz-selection {
-  background-color: rgb(182, 38, 44);
+  background-color: $color-accent;
   color: white;
 }

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -1,3 +1,4 @@
+@import "variables";
 @import "global";
 @import "footer";
 

--- a/assets/sass/profile.scss
+++ b/assets/sass/profile.scss
@@ -10,18 +10,12 @@
       width: 10rem;
       height: 10rem;
       border: 0.5em solid #3d3d3d;
-      border-right-color: rgb(182, 38, 44);
-      border-bottom-color: rgb(182, 38, 44);
+      border-right-color: $color-accent;
+      border-bottom-color: $color-accent;
       border-radius: 50%;
-      -webkit-transition: transform 0.8s ease-in-out;
-      -moz-transition: transform 0.8s ease-in-out;
       transition: transform 0.8s ease-in-out;
     }
     &:hover .spinner {
-      -webkit-transform: rotate(180deg);
-      -moz-transform: rotate(180deg);
-      -ms-transform: rotate(180deg);
-      -o-transform: rotate(180deg);
       transform: rotate(180deg);
     }
     .img {
@@ -34,8 +28,6 @@
       background-position: center;
       background-size: cover;
       border-radius: 50%;
-      -webkit-border-radius: 50%;
-      -moz-border-radius: 50%;
     }
   }
   .name {
@@ -51,7 +43,7 @@
   .title {
     font-size: 1rem;
     text-transform: uppercase;
-    color: rgb(182, 38, 44);
+    color: $color-accent;
     margin: 0.8em auto;
   }
   .bio {

--- a/assets/sass/variables.scss
+++ b/assets/sass/variables.scss
@@ -1,0 +1,1 @@
+$color-accent: rgb(182, 38, 44);

--- a/layouts/partials/actions.html
+++ b/layouts/partials/actions.html
@@ -1,7 +1,7 @@
 {{ with .Site.Params.actions -}}
 <section class="actions">
   {{ range . }}
-  <a class="action" href="{{ .url }}" target="_blank">{{ .name }}</a>
+  <a class="action" href="{{ .url }}" target="_blank" rel="noopener">{{ .name }}</a>
   {{ end }}
 </section>
 {{- end }}

--- a/layouts/partials/contacts.html
+++ b/layouts/partials/contacts.html
@@ -1,63 +1,27 @@
 {{ with .Site.Params.contacts -}}
+{{- $services := dict
+  "bitbucket" (dict "url" "https://bitbucket.org/%s" "icon" "fab fa-bitbucket")
+  "devto" (dict "url" "https://dev.to/%s" "icon" "fab fa-dev")
+  "email" (dict "url" "mailto:%s" "icon" "fas fa-envelope")
+  "facebook" (dict "url" "https://facebook.com/%s" "icon" "fab fa-facebook")
+  "github" (dict "url" "https://github.com/%s" "icon" "fab fa-github")
+  "gitlab" (dict "url" "https://gitlab.com/%s" "icon" "fab fa-gitlab")
+  "hackerrank" (dict "url" "https://hackerrank.com/%s" "icon" "fab fa-hackerrank")
+  "instagram" (dict "url" "https://instagram.com/%s" "icon" "fab fa-instagram")
+  "keybase" (dict "url" "https://keybase.io/%s" "icon" "fab fa-keybase")
+  "linkedin" (dict "url" "https://linkedin.com/in/%s" "icon" "fab fa-linkedin")
+  "medium" (dict "url" "https://medium.com/%s" "icon" "fab fa-medium")
+  "stackoverflow" (dict "url" "https://stackoverflow.com/users/%s" "icon" "fab fa-stack-overflow")
+  "twitter" (dict "url" "https://twitter.com/%s" "icon" "fab fa-twitter")
+  "xing" (dict "url" "https://xing.com/profile/%s" "icon" "fab fa-xing")
+-}}
 <section class="contacts">
   {{- range $service, $id := . -}}
-    {{- if (eq $service "github") }}
-  <a class="contact" href="https://github.com/{{ $id }}" target="_blank">
-    <i class="fab fa-github" aria-hidden="true"></i>
+    {{- with index $services $service }}
+  <a class="contact" href="{{ printf .url $id }}" target="_blank" rel="noopener">
+    <i class="{{ .icon }}" aria-hidden="true"></i>
   </a>
-    {{- else if (eq $service "twitter") }}
-  <a class="contact" href="https://twitter.com/{{ $id }}" target="_blank">
-    <i class="fab fa-twitter" aria-hidden="true"></i>
-  </a>
-    {{- else if (eq $service "facebook") }}
-  <a class="contact" href="https://facebook.com/{{ $id }}" target="_blank">
-    <i class="fab fa-facebook" aria-hidden="true"></i>
-  </a>
-    {{- else if (eq $service "linkedin") }}
-  <a class="contact" href="https://linkedin.com/in/{{ $id }}" target="_blank">
-    <i class="fab fa-linkedin" aria-hidden="true"></i>
-  </a>
-    {{- else if (eq $service "xing") }}
-  <a class="contact" href="https://xing.com/profile/{{ $id }}" target="_blank">
-    <i class="fab fa-xing" aria-hidden="true"></i>
-  </a>
-    {{- else if (eq $service "instagram") }}
-  <a class="contact" href="https://instagram.com/{{ $id }}" target="_blank">
-    <i class="fab fa-instagram" aria-hidden="true"></i>
-  </a>
-    {{- else if (eq $service "stackoverflow") }}
-  <a class="contact" href="https://stackoverflow.com/users/{{ $id }}" target="_blank">
-    <i class="fab fa-stack-overflow" aria-hidden="true"></i>
-  </a>
-    {{- else if (eq $service "medium") }}
-  <a class="contact" href="https://medium.com/{{ $id }}" target="_blank">
-    <i class="fab fa-medium" aria-hidden="true"></i>
-  </a>
-    {{- else if (eq $service "email") }}
-  <a class="contact" href="mailto:{{ $id }}" target="_blank">
-    <i class="fas fa-envelope" aria-hidden="true"></i>
-  </a>
-    {{- else if (eq $service "keybase") }}
-  <a class="contact" href="https://keybase.io/{{ $id }}" target="_blank">
-    <i class="fab fa-keybase" aria-hidden="true"></i>
-  </a>
-    {{- else if (eq $service "gitlab") }}
-  <a class="contact" href="https://gitlab.com/{{ $id }}" target="_blank">
-    <i class="fab fa-gitlab" aria-hidden="true"></i>
-  </a>
-    {{- else if (eq $service "devto") }}
-  <a class="contact" href="https://dev.to/{{ $id }}" target="_blank">
-    <i class="fab fa-dev" aria-hidden="true"></i>
-  </a>
-    {{- else if (eq $service "hackerrank") }}
-  <a class="contact" href="https://hackerrank.com/{{ $id }}" target="_blank">
-    <i class="fab fa-hackerrank" aria-hidden="true"></i>
-  </a>
-  {{- else if (eq $service "bitbucket") }}
-  <a class="contact" href="https://bitbucket.org/{{ $id }}" target="_blank">
-    <i class="fab fa-bitbucket" aria-hidden="true"></i>
-  </a>
-    {{- end }}
+    {{- end -}}
   {{- end }}
 </section>
 {{- end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,7 +4,7 @@
   <p class="copyright">{{ . | markdownify }}</p>
   {{- end }}
   {{ if or ( not ( isset . "poweredby" ) ) ( .poweredby ) -}}
-  <p class="powered-by">Powered by <a href="https://gohugo.io/" target="_blank">Hugo</a> & <a href="https://github.com/posquit0/hugo-awesome-identity" target="_blank">Awesome Identity</a>.</p>
+  <p class="powered-by">Powered by <a href="https://gohugo.io/" target="_blank" rel="noopener">Hugo</a> & <a href="https://github.com/posquit0/hugo-awesome-identity" target="_blank" rel="noopener">Awesome Identity</a>.</p>
   {{- end }}
 </footer>
 {{- end }}


### PR DESCRIPTION
## Summary

- **`contacts.html`**: replace the 14-branch `if/else` chain with a `service → (url, icon)` lookup table (76 lines → 27). Adding a new contact service is now a one-line change. Iteration order over the params map is unchanged (alphabetical), so rendered output is identical
- **Security hardening**: add `rel="noopener"` to all `target="_blank"` links (contacts, actions, footer) to prevent reverse tabnabbing — no visual change
- **SCSS**: extract the accent color `rgb(182, 38, 44)` into `$color-accent`, merge the duplicated `.action:after` blocks, and remove vendor prefixes obsolete in every browser released since ~2018 (`-webkit/-moz/-ms/-o` transition/transform/border-radius, `::-moz-selection`)

## Verification

Built the example site with **all 14 contact types plus actions configured**, before and after:

- HTML diff: only `rel="noopener"` additions (and the CSS fingerprint hash)
- Compiled CSS diff: only the removed prefixed declarations; every color compiles to the same value (`#b6262c`, `#d63940`, `rgba(182,38,44,0.15)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)