### PR TITLE
:memo: Improve example site (copyright range, demo data)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2020 Byungjin Park
+Copyright (c) 2019-2026 Byungjin Park
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Please use the [issue tracker](https://github.com/posquit0/hugo-awesome-identity
 
 Provided under the terms of the [MIT License](https://github.com/posquit0/hugo-awesome-identity/blob/master/LICENSE).
 
-Copyright © 2019-2020, [Byungjin Park](http://www.posquit0.com).
+Copyright © 2019-2026, [Byungjin Park](http://www.posquit0.com).
 
 
 ## See Also

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -3,6 +3,13 @@ baseURL = "https://example.com"
 title = "Awesome Identity for Hugo"
 
 
+## HTTP meta tags & OpenGraph Configurations
+[params.meta]
+  description = "Awesome Identity is a single-page Hugo theme to introduce yourself."
+  keywords = "profile, about me, identity, hugo, theme"
+  images = ["/images/portrait-default.png"]
+
+
 ## Profile Configurations
 [params.profile]
   portrait = "/images/portrait-default.png"
@@ -17,7 +24,34 @@ title = "Awesome Identity for Hugo"
   """
 
 
+## Contacts Configurations
+[params.contacts]
+  email = "john.smith@example.com"
+  github = "john.smith"
+  gitlab = "john.smith"
+  twitter = "john.smith"
+  linkedin = "john.smith"
+  instagram = "john.smith"
+  stackoverflow = "7919458"
+  medium = "john.smith"
+  devto = "john.smith"
+
+
+## Actions Configurations
+[[params.actions]]
+  name = "Resume"
+  url = "https://example.com/resume.pdf"
+
+[[params.actions]]
+  name = "Blog"
+  url = "https://blog.example.com"
+
+[[params.actions]]
+  name = "Portfolio"
+  url = "https://example.com/portfolio"
+
+
 ## Footer Configurations
 [params.footer]
-  copyright = "© 2019-2020 Byungjin Park. [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)."
+  copyright = "© 2019-2026 Byungjin Park. [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)."
   poweredBy = true


### PR DESCRIPTION
## Summary

- Update the copyright year range **2019-2020 → 2019-2026** in all three places it appears: `LICENSE`, the README license section, and the example footer config (the fictional `© 2019 John Smith` inside a README config snippet is left as-is)
- Populate `exampleSite/config.toml` with the theme's full feature set so the demo actually showcases it (previously the demo rendered no contacts, actions, or meta tags at all):
  - `[params.meta]` description / keywords / OpenGraph image
  - nine `[params.contacts]` entries using the same `john.smith` example handles documented in the README
  - three `[[params.actions]]` buttons with `example.com` URLs

## Test plan

- [x] Example site builds on Hugo 0.163.1; output contains 9 contact icons, 3 action buttons, and `og:description`/`og:image` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)