### PR TITLE
:construction_worker: Tidy CI workflow (2-space YAML, bump actions/checkout to v6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,29 +15,29 @@ jobs:
         # Oldest supported (theme.toml min_version) and latest release.
         hugo-version: ["0.128.0", "0.163.1"]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: true
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        submodules: true
 
-      - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v3
-        with:
-          hugo-version: ${{ matrix.hugo-version }}
-          extended: true
+    - name: Setup Hugo
+      uses: peaceiris/actions-hugo@v3
+      with:
+        hugo-version: ${{ matrix.hugo-version }}
+        extended: true
 
-      - name: Build example site
-        working-directory: exampleSite
-        run: hugo --buildDrafts --themesDir ../../ -t ${{ github.event.repository.name }}
+    - name: Build example site
+      working-directory: exampleSite
+      run: hugo --buildDrafts --themesDir ../../ -t ${{ github.event.repository.name }}
 
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.3"
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: "3.3"
 
-      - name: Install HTML Proofer
-        run: gem install html-proofer
+    - name: Install HTML Proofer
+      run: gem install html-proofer
 
-      - name: Test generated HTML
-        working-directory: exampleSite
-        run: htmlproofer public --allow-hash-href --ignore-empty-alt --disable-external
+    - name: Test generated HTML
+      working-directory: exampleSite
+      run: htmlproofer public --allow-hash-href --ignore-empty-alt --disable-external


### PR DESCRIPTION
## Summary

- Re-indent the workflow YAML so every nesting level is exactly 2 spaces — sequence items now align with their parent key (`steps:` → `- name:`), matching the style of the repo's previous CircleCI config
- **actions/checkout v4 → v6** (latest release v6.0.3, checked via the GitHub releases API)
- `peaceiris/actions-hugo@v3` (latest v3.2.1) and `ruby/setup-ruby@v1` (latest v1.313.0) are already on their latest major tags — unchanged

No functional change to the pipeline; this PR's own CI run is the verification.

## Test plan

- [x] YAML parses (validated with Ruby's YAML parser)
- [ ] CI matrix on this PR runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)