### PR TITLE
:sparkles: Add dark mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ Currently, Awesome Identity supports: Email, GitHub, Twitter, Facebook, LinkedIn
 
 ### Colors
 
+### Dark Mode
+
+The theme follows the visitor's system color scheme (`prefers-color-scheme`) automatically. To force a specific scheme, set the `appearance` parameter in your site config:
+
+```toml
+[params]
+  # One of "auto" (default), "light", or "dark".
+  appearance = "auto"
+```
+
 ### Internationalization (i18n)
 
 

--- a/assets/sass/actions.scss
+++ b/assets/sass/actions.scss
@@ -12,7 +12,7 @@
     line-height: 2em;
     text-transform: uppercase;
     font-weight: 700;
-    color: rgba(0, 0, 0, 1);
+    color: var(--color-text);
 
     &:after {
       content: "";
@@ -23,7 +23,7 @@
       height: 2px;
       left: 50%;
       bottom: -0.3em;
-      background: lighten($color-accent, 10%);
+      background: var(--color-accent-light);
       transform: translateX(-50%);
     }
     &:hover:after {
@@ -31,6 +31,6 @@
     }
   }
   .action:hover {
-    color: lighten(black, 40%);
+    color: var(--color-text-muted);
   }
 }

--- a/assets/sass/contacts.scss
+++ b/assets/sass/contacts.scss
@@ -10,16 +10,16 @@
     line-height: 2.2em;
     margin-left: 0.1em;
     margin-right: 0.1em;
-    background: #f9f9fb;
+    background: var(--color-contact-bg);
     border-radius: 100%;
-    color: #535358;
+    color: var(--color-contact-fg);
     text-align: center;
     transition: all 0.3s ease-in-out;
   }
   .contact:hover {
-    background: $color-accent;
+    background: var(--color-accent);
     color: #fff;
-    box-shadow: 0 0 1px 7px rgba($color-accent, 0.15);
+    box-shadow: 0 0 1px 7px var(--color-accent-shadow);
     position: relative;
   }
 }

--- a/assets/sass/footer.scss
+++ b/assets/sass/footer.scss
@@ -3,7 +3,7 @@
   width: 92%;
   height: auto;
   box-sizing: border-box;
-  color: #4f515d;
+  color: var(--color-footer-fg);
   font-size: 0.8rem;
   text-align: center;
   text-transform: uppercase;
@@ -11,7 +11,7 @@
   padding-top: 18px;
   padding-bottom: 18px;
   border: 0;
-  border-top: 1px solid #eee;
+  border-top: 1px solid var(--color-border);
 
   @media only screen and (min-width: 1024px) {
     width: 1024px;
@@ -21,6 +21,6 @@
     margin-bottom: 0.4em;
   }
   a:hover {
-    color: #4f515d;
+    color: var(--color-footer-fg);
   }
 }

--- a/assets/sass/global.scss
+++ b/assets/sass/global.scss
@@ -8,6 +8,8 @@ body {
   font-family: Jura, sans-serif;
   font-size: 1rem;
   height: 100%;
+  background-color: var(--color-bg);
+  color: var(--color-text);
 }
 
 body {
@@ -27,7 +29,7 @@ body {
 }
 
 a {
-  color: $color-accent;
+  color: var(--color-accent);
   text-decoration: none;
   transition: color 0.5s;
 
@@ -39,6 +41,6 @@ a {
 }
 
 ::selection {
-  background-color: $color-accent;
+  background-color: var(--color-accent);
   color: white;
 }

--- a/assets/sass/profile.scss
+++ b/assets/sass/profile.scss
@@ -9,9 +9,9 @@
     .spinner {
       width: 10rem;
       height: 10rem;
-      border: 0.5em solid #3d3d3d;
-      border-right-color: $color-accent;
-      border-bottom-color: $color-accent;
+      border: 0.5em solid var(--color-spinner);
+      border-right-color: var(--color-accent);
+      border-bottom-color: var(--color-accent);
       border-radius: 50%;
       transition: transform 0.8s ease-in-out;
     }
@@ -43,7 +43,7 @@
   .title {
     font-size: 1rem;
     text-transform: uppercase;
-    color: $color-accent;
+    color: var(--color-accent);
     margin: 0.8em auto;
   }
   .bio {

--- a/assets/sass/variables.scss
+++ b/assets/sass/variables.scss
@@ -1,1 +1,47 @@
 $color-accent: rgb(182, 38, 44);
+
+@mixin light-colors {
+  color-scheme: light;
+  --color-bg: #fff;
+  --color-text: #000;
+  --color-text-muted: #666;
+  --color-accent: #{$color-accent};
+  --color-accent-light: #{lighten($color-accent, 10%)};
+  --color-accent-shadow: #{rgba($color-accent, 0.15)};
+  --color-contact-bg: #f9f9fb;
+  --color-contact-fg: #535358;
+  --color-footer-fg: #4f515d;
+  --color-border: #eee;
+  --color-spinner: #3d3d3d;
+}
+
+@mixin dark-colors {
+  color-scheme: dark;
+  --color-bg: #121214;
+  --color-text: #e6e6e6;
+  --color-text-muted: #9a9a9a;
+  --color-accent: #{lighten($color-accent, 12%)};
+  --color-accent-light: #{lighten($color-accent, 22%)};
+  --color-accent-shadow: #{rgba(lighten($color-accent, 12%), 0.2)};
+  --color-contact-bg: #232328;
+  --color-contact-fg: #b6b6bc;
+  --color-footer-fg: #a0a2ad;
+  --color-border: #2c2c2e;
+  --color-spinner: #d0d0d0;
+}
+
+:root {
+  @include light-colors;
+}
+
+// Forced via `appearance = "dark"` in site params.
+:root[data-color-scheme="dark"] {
+  @include dark-colors;
+}
+
+// Follow the system preference unless `appearance = "light"` is set.
+@media (prefers-color-scheme: dark) {
+  :root:not([data-color-scheme="light"]) {
+    @include dark-colors;
+  }
+}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<html>
+{{- $appearance := .Site.Params.appearance | default "auto" }}
+<html{{ if in (slice "light" "dark") $appearance }} data-color-scheme="{{ $appearance }}"{{ end }}>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
## Summary

The theme now follows the visitor's system color scheme automatically via `prefers-color-scheme`, with an optional override:

```toml
[params]
  # auto (default) | light | dark
  appearance = "auto"
```

Implementation:

- All theme colors move from hardcoded values to CSS custom properties; light and dark palettes live in `assets/sass/variables.scss` (the existing `$color-accent` SCSS variable remains the single source for the brand red)
- Dark palette keeps the same visual language — accent red is lightened ~12% for contrast on dark backgrounds, surfaces use #121214/#232328
- `appearance = "light"` pins the original look; `"dark"` forces dark via `data-color-scheme` on `<html>`; `auto` (or unset) follows the OS setting
- `color-scheme` is declared so built-in UI (scrollbars, form controls) matches
- README gains a Dark Mode section

**With no config change, light-mode rendering is identical to before** — all light palette values compile to the exact same colors.

## Test plan

- [x] Built all three `appearance` modes: `<html>` attribute and compiled CSS verified for each
- [x] Screenshotted forced light/dark builds in headless Chromium — light matches the original theme exactly; dark renders the new palette (profile, accent title, footer, selection all themed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)