### PR TITLE
:sparkles: Add a color-scheme toggle switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,12 +117,16 @@ Currently, Awesome Identity supports: Email, GitHub, Twitter, Facebook, LinkedIn
 
 ### Dark Mode
 
-The theme follows the visitor's system color scheme (`prefers-color-scheme`) automatically. To force a specific scheme, set the `appearance` parameter in your site config:
+The theme follows the visitor's system color scheme (`prefers-color-scheme`) automatically, and shows an on/off switch in the top-right corner so visitors can flip the scheme themselves. The visitor's choice is stored in `localStorage` and takes precedence on later visits.
+
+To change the default scheme or hide the switch, set these parameters in your site config:
 
 ```toml
 [params]
-  # One of "auto" (default), "light", or "dark".
+  # Default scheme: one of "auto" (default), "light", or "dark".
   appearance = "auto"
+  # Set to false to hide the toggle switch.
+  schemeToggle = true
 ```
 
 ### Internationalization (i18n)

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -5,3 +5,4 @@
 @import "profile";
 @import "contacts";
 @import "actions";
+@import "scheme-toggle";

--- a/assets/sass/scheme-toggle.scss
+++ b/assets/sass/scheme-toggle.scss
@@ -1,0 +1,49 @@
+.scheme-toggle {
+  position: fixed;
+  top: 1.2rem;
+  right: 1.2rem;
+  z-index: 10;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  box-sizing: border-box;
+  width: 3.6em;
+  height: 2em;
+  padding: 0 0.5em;
+  border: 0;
+  border-radius: 1em;
+  background: var(--color-contact-bg);
+  color: var(--color-contact-fg);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.3s ease-in-out;
+
+  i {
+    z-index: 1;
+    font-size: 0.85em;
+  }
+
+  .thumb {
+    position: absolute;
+    top: 0.2em;
+    left: 0.2em;
+    width: 1.6em;
+    height: 1.6em;
+    border-radius: 50%;
+    background: var(--color-accent);
+    transition: transform 0.3s ease-in-out;
+  }
+
+  &[aria-checked="false"] .fa-sun,
+  &[aria-checked="true"] .fa-moon {
+    color: #fff;
+  }
+
+  &[aria-checked="true"] .thumb {
+    transform: translateX(1.6em);
+  }
+
+  &:hover {
+    box-shadow: 0 0 1px 4px var(--color-accent-shadow);
+  }
+}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,6 +3,15 @@
 <html{{ if in (slice "light" "dark") $appearance }} data-color-scheme="{{ $appearance }}"{{ end }}>
   <head>
     <meta charset="UTF-8" />
+    <script>
+      // Restore the visitor's color-scheme choice before first paint.
+      try {
+        var scheme = localStorage.getItem('color-scheme');
+        if (scheme === 'light' || scheme === 'dark') {
+          document.documentElement.setAttribute('data-color-scheme', scheme);
+        }
+      } catch (e) {}
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -33,6 +42,7 @@
     <link rel="manifest" href="/manifest.json">
   </head>
   <body>
+{{ partial "scheme-toggle.html" . }}
     <div class="wrap">
 {{ partial "profile.html" . }}
 {{ partial "contacts.html" . }}

--- a/layouts/partials/scheme-toggle.html
+++ b/layouts/partials/scheme-toggle.html
@@ -1,0 +1,33 @@
+{{ if ne .Site.Params.schemeToggle false -}}
+<button id="scheme-toggle" class="scheme-toggle" type="button" role="switch" aria-checked="false" aria-label="Dark mode">
+  <i class="fas fa-sun" aria-hidden="true"></i>
+  <i class="fas fa-moon" aria-hidden="true"></i>
+  <span class="thumb"></span>
+</button>
+<script>
+  (function () {
+    var root = document.documentElement;
+    var toggle = document.getElementById('scheme-toggle');
+    var media = window.matchMedia('(prefers-color-scheme: dark)');
+
+    function current() {
+      var forced = root.getAttribute('data-color-scheme');
+      return forced === 'light' || forced === 'dark'
+        ? forced
+        : (media.matches ? 'dark' : 'light');
+    }
+    function update() {
+      toggle.setAttribute('aria-checked', current() === 'dark');
+    }
+
+    toggle.addEventListener('click', function () {
+      var next = current() === 'dark' ? 'light' : 'dark';
+      root.setAttribute('data-color-scheme', next);
+      try { localStorage.setItem('color-scheme', next); } catch (e) {}
+      update();
+    });
+    media.addEventListener('change', update);
+    update();
+  })();
+</script>
+{{- end }}


### PR DESCRIPTION
## Summary

Follow-up to #36 (which was merged while this was in flight): adds the visitor-facing **on/off switch** for dark mode.

- Fixed sun/moon pill switch in the top-right corner (`role="switch"`, keyboard- and screen-reader-accessible via a real `<button>`)
- Clicking flips the scheme regardless of the configured `appearance` default; the choice is persisted in `localStorage` and **restored before first paint** (inline head script) so there is no flash of the wrong scheme
- Visitor choice precedence: localStorage > `appearance` param > system `prefers-color-scheme`
- Site owners can hide the switch with `params.schemeToggle = false` (documented in the README)

All inline JS is static with no template interpolation (no injection surface).

## Test plan

- [x] Headless Chromium: click flips palette + `aria-checked`, body background switches to the dark value, choice survives a full reload
- [x] Example site builds on Hugo 0.163.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)