### PR TITLE
:lipstick: Keep contact hover highlight off neighboring icons

### DIFF
--- a/assets/sass/contacts.scss
+++ b/assets/sass/contacts.scss
@@ -8,8 +8,7 @@
     width: 2.2em;
     height: 2.2em;
     line-height: 2.2em;
-    margin-left: 0.1em;
-    margin-right: 0.1em;
+    margin: 0.25em;
     background: var(--color-contact-bg);
     border-radius: 100%;
     color: var(--color-contact-fg);
@@ -20,6 +19,5 @@
     background: var(--color-accent);
     color: #fff;
     box-shadow: 0 0 1px 7px var(--color-accent-shadow);
-    position: relative;
   }
 }


### PR DESCRIPTION
## Summary

The contact icon hover highlight (`box-shadow` with 7px spread + 1px blur ≈ 8px) extended past the 0.2em (~3.8px) gap between icons and bled onto neighbors.

- Widen the per-icon margin to `0.25em` on all sides — measured edge-to-edge gap goes from ~8.6px (touching) to **~14.4px**, comfortably clearing the 8px ring
- The vertical margin keeps wrapped rows clear of each other on narrow screens
- Remove the `position: relative` hover hack introduced in #18 — it only painted the overlapping ring *on top of* neighbors rather than removing the overlap, and is unnecessary now

## Test plan

- [x] Headless Chromium: measured adjacent-icon gap ≥ shadow extent; hover screenshot shows the ring fully clear of neighbors
- [x] Example site builds on Hugo 0.163.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)